### PR TITLE
Add NameHandlerCache

### DIFF
--- a/PrefPro/Configuration.cs
+++ b/PrefPro/Configuration.cs
@@ -166,6 +166,7 @@ namespace PrefPro
         public void Save()
         {
             DalamudApi.PluginInterface.SavePluginConfig(this);
+            _prefPro.NameHandlerCache.Refresh();
         }
     }
 }

--- a/PrefPro/DalamudApi.cs
+++ b/PrefPro/DalamudApi.cs
@@ -21,7 +21,7 @@ public class DalamudApi
     // [PluginService] public static IDtrBar DtrBar { get; private set; } = null;
     // [PluginService] public static IFateTable FateTable { get; private set; } = null;
     // [PluginService] public static IFlyTextGui FlyTextGui { get; private set; } = null;
-    // [PluginService] public static IFramework Framework { get; private set; } = null;
+    [PluginService] public static IFramework Framework { get; private set; } = null;
     // [PluginService] public static IGameGui GameGui { get; private set; } = null;
     // [PluginService] public static IGameNetwork GameNetwork { get; private set; } = null;
     // [PluginService] public static IGamepadState GamePadState { get; private set; } = null;

--- a/PrefPro/NameHandlerCache.cs
+++ b/PrefPro/NameHandlerCache.cs
@@ -1,0 +1,111 @@
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Plugin.Services;
+using PrefPro.Settings;
+
+namespace PrefPro;
+
+public class NameHandlerCache
+{
+    private readonly Configuration _configuration;
+    private string? _playerName;
+
+    public HandlerConfig Config { get; private set; } = HandlerConfig.None;
+
+    public NameHandlerCache(Configuration configuration)
+    {
+        _configuration = configuration;
+        DalamudApi.ClientState.Logout += OnLogout;
+        DalamudApi.Framework.Update += FrameworkOnUpdate;
+    }
+
+    private void FrameworkOnUpdate(IFramework framework)
+    {
+        if (DalamudApi.ClientState.IsLoggedIn && DalamudApi.ClientState.LocalPlayer is { } localPlayer) {
+            DalamudApi.Framework.Update -= FrameworkOnUpdate;
+            _playerName = localPlayer.Name.TextValue;
+            Refresh();
+        }
+    }
+
+    private void OnLogout(int type, int code)
+    {
+        if (_playerName != null) {
+            _playerName = null;
+            Config = HandlerConfig.None;
+            DalamudApi.Framework.Update += FrameworkOnUpdate;
+        }
+    }
+
+    public void Refresh()
+    {
+        if (_playerName != null) {
+            Config = CreateConfig(_configuration, _playerName);
+        }
+    }
+
+    private static HandlerConfig CreateConfig(Configuration config, string playerName)
+    {
+        var data = new HandlerConfig();
+
+        if (config.Name != playerName)
+        {
+            data.ApplyFull = true;
+            data.ApplyFirst = true;
+            data.ApplyLast = true;
+        }
+        else
+        {
+            data.ApplyFull = config.FullName != NameSetting.FirstLast;
+            data.ApplyFirst = config.FirstName != NameSetting.FirstOnly;
+            data.ApplyLast = config.LastName != NameSetting.LastOnly;
+        }
+
+        if (data is { ApplyFirst: false, ApplyLast: false, ApplyFull: false })
+        {
+            data.Apply = false;
+        }
+        else
+        {
+            data.Apply = true;
+
+            data.NameFull = new TextPayload(GetNameText(playerName, config.Name, config.FullName));
+            data.NameFirst = new TextPayload(GetNameText(playerName, config.Name, config.FirstName));
+            data.NameLast = new TextPayload(GetNameText(playerName, config.Name, config.LastName));
+        }
+
+        return data;
+    }
+
+    private static string GetNameText(string playerName, string configName, NameSetting setting)
+    {
+        switch (setting) {
+            case NameSetting.FirstLast:
+                return configName;
+            case NameSetting.FirstOnly:
+                return configName.Split(' ')[0];
+            case NameSetting.LastOnly:
+                return configName.Split(' ')[1];
+            case NameSetting.LastFirst:
+                var split = configName.Split(' ');
+                return $"{split[1]} {split[0]}";
+            default:
+                return playerName;
+        }
+    }
+}
+
+public class HandlerConfig
+{
+    public bool Apply;
+    public bool ApplyFull;
+    public bool ApplyFirst;
+    public bool ApplyLast;
+    public TextPayload NameFull = null!;
+    public TextPayload NameFirst = null!;
+    public TextPayload NameLast = null!;
+
+    public static readonly HandlerConfig None = new()
+    {
+        Apply = false
+    };
+}


### PR DESCRIPTION
I did most of this refactoring a while ago just locally when I was trying to reduce the number of allocations PrefPro was making in `HandleName`. But with the new off-thread player stuff happening I thought it might be worth PRing it with some modifications in case you're interested in using it.

The basic idea is to pre-compute everything needed for name replacement (conditions, replacement `SeString`s, etc.) in one place to reduce allocations and improve performance. As a bonus we also no longer need to check for the local player on each hooked call (it's cached once per character after login and only in the main thread) which should also fix the Teleporter issue. There is also some refactoring in `HandleName` to reduce the work done there (especially in cases where no replacement is performed).

This is probably a bigger refactoring than is needed just for the current bug, though, which I can understand wanting to avoid.