### PR TITLE
More defensive name handling

### DIFF
--- a/PrefPro/Configuration.cs
+++ b/PrefPro/Configuration.cs
@@ -146,7 +146,7 @@ namespace PrefPro
             {
                 var ch = new ConfigHolder
                 {
-                    Name = _prefPro.PlayerName,
+                    Name = _prefPro.PlayerName ?? "",
                     FullName = NameSetting.FirstLast,
                     FirstName = NameSetting.FirstOnly,
                     LastName = NameSetting.LastOnly,

--- a/PrefPro/NameHandlerCache.cs
+++ b/PrefPro/NameHandlerCache.cs
@@ -7,7 +7,7 @@ namespace PrefPro;
 public class NameHandlerCache
 {
     private readonly Configuration _configuration;
-    private string? _playerName;
+    public string? PlayerName;
 
     public HandlerConfig Config { get; private set; } = HandlerConfig.None;
 
@@ -22,15 +22,15 @@ public class NameHandlerCache
     {
         if (DalamudApi.ClientState.IsLoggedIn && DalamudApi.ClientState.LocalPlayer is { } localPlayer) {
             DalamudApi.Framework.Update -= FrameworkOnUpdate;
-            _playerName = localPlayer.Name.TextValue;
+            PlayerName = localPlayer.Name.TextValue;
             Refresh();
         }
     }
 
     private void OnLogout(int type, int code)
     {
-        if (_playerName != null) {
-            _playerName = null;
+        if (PlayerName != null) {
+            PlayerName = null;
             Config = HandlerConfig.None;
             DalamudApi.Framework.Update += FrameworkOnUpdate;
         }
@@ -38,14 +38,19 @@ public class NameHandlerCache
 
     public void Refresh()
     {
-        if (_playerName != null) {
-            Config = CreateConfig(_configuration, _playerName);
+        if (PlayerName != null) {
+            Config = CreateConfig(_configuration, PlayerName);
         }
     }
 
     private static HandlerConfig CreateConfig(Configuration config, string playerName)
     {
         var data = new HandlerConfig();
+
+        if (string.IsNullOrEmpty(config.Name))
+        {
+            return HandlerConfig.None;
+        }
 
         if (config.Name != playerName)
         {
@@ -78,7 +83,8 @@ public class NameHandlerCache
 
     private static string GetNameText(string playerName, string configName, NameSetting setting)
     {
-        switch (setting) {
+        switch (setting)
+        {
             case NameSetting.FirstLast:
                 return configName;
             case NameSetting.FirstOnly:

--- a/PrefPro/PluginUI.cs
+++ b/PrefPro/PluginUI.cs
@@ -25,18 +25,16 @@ namespace PrefPro
 
         private string _tmpFirstName = "";
         private string _tmpLastName = "";
+        private bool _resetNames;
 
         public bool SettingsVisible
         {
             get => _settingsVisible;
-            // set => _settingsVisible = value;
             set
             {
                 if (value)
                 {
-                    var split = _configuration.Name.Split(' ');
-                    _tmpFirstName = split[0];
-                    _tmpLastName = split[1];
+                    _resetNames = true;
                 }
                 _settingsVisible = value;
             }
@@ -68,6 +66,27 @@ namespace PrefPro
             ImGui.SetNextWindowSize(size, ImGuiCond.FirstUseEver);
             if (ImGui.Begin("PrefPro Config", ref _settingsVisible, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
             {
+                if (_prefPro.PlayerName is null || DalamudApi.ClientState.LocalPlayer is null)
+                {
+                    ImGui.TextWrapped("Configuration is not available while logged out or in a loading screen.");
+                    ImGui.End();
+                    return;
+                }
+
+                if (_configuration.Name == "")
+                {
+                    DalamudApi.PluginLog.Debug($"Configuration name is empty, setting to current player name ({_prefPro.PlayerName}).");
+                    _configuration.Name = _prefPro.PlayerName;
+                }
+
+                if (_resetNames)
+                {
+                    var split = _configuration.Name.Split(' ');
+                    _tmpFirstName = split[0];
+                    _tmpLastName = split[1];
+                    _resetNames = false;
+                }
+
                 var enabled = _configuration.Enabled;
                 var currentGender = _configuration.Gender;
                 var currentRace = _configuration.Race;

--- a/PrefPro/PrefPro.cs
+++ b/PrefPro/PrefPro.cs
@@ -42,7 +42,7 @@ public unsafe class PrefPro : IDalamudPlugin
 
     public readonly NameHandlerCache NameHandlerCache;
 
-    public string PlayerName => DalamudApi.ClientState.LocalPlayer?.Name.ToString();
+    public string? PlayerName => NameHandlerCache.PlayerName;
     public int PlayerGender => DalamudApi.ClientState.LocalPlayer?.Customize[(int)CustomizeIndex.Gender] ?? 0;
     public RaceSetting PlayerRace => (RaceSetting) (DalamudApi.ClientState.LocalPlayer?.Customize[(int)CustomizeIndex.Race] ?? 0);
     public TribeSetting PlayerTribe => (TribeSetting) (DalamudApi.ClientState.LocalPlayer?.Customize[(int)CustomizeIndex.Tribe] ?? 0);


### PR DESCRIPTION
Unfortunately the last fix was not enough to due `ConfigHolder.GetOrDefault` also depending on the current name. To prevent this I pull the name from `NameHandlerCache` instead (which is safe on any thread) while allowing the name to default to `""` if unavailable. Then in the settings window there's a bunch of defensive code to make sure the player exists first and if so, load the real name in there.